### PR TITLE
update script for debian/ubuntu

### DIFF
--- a/debian-based-distro-update-upgrade/update.sh
+++ b/debian-based-distro-update-upgrade/update.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+sudo apt update        # update the apt cache
+sudo apt upgrade -y    # upgrade the system packages
+sudo apt autoclean     # uninstall dependencies that are not required
+sudo apt autoremove    # remove non-required downloaded files
+


### PR DESCRIPTION
This script runs apt update and upgrade
after the operation is done, it starts cleanup of packages downloaded which are not required anymore
Later cleans up the extra files, which are not required as a dependency.

This should run smoothly on debian based distros.
I have tested it on Ubuntu