### PR TITLE
Git uncommit files function

### DIFF
--- a/git-uncommit-files/README.md
+++ b/git-uncommit-files/README.md
@@ -1,0 +1,13 @@
+# git-uncommit-files
+
+This function allows the user to uncommit files from the last commit. It is assumed that the user has not pushed the repository to remote.
+
+If all the files in the commit are selected, the commit itself will also be removed. If only a proper subset of files are selected, the commit will remain with the unselected files.
+
+## Add the function to your environment
+ 1. Execute permissions `chmod +x git-uncommit-files.sh`
+ 2. Source the file `. git-uncommit-files.sh`.
+ 3. Optionally source in `.bashrc`: `echo . $(pwd)/git-uncommit-files.sh >> ~/.bashrc` 
+
+## Example use
+`git-uncommit-files file1 file2 ...` will remove `file1` and `file2` from last commit. The files will not be deleted.

--- a/git-uncommit-files/git-uncommit-files.sh
+++ b/git-uncommit-files/git-uncommit-files.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+git-uncommit-files() {
+   if [ "$1" == "-h" -o "$#" -lt 1 ]; then
+      echo "Usage: 'git-uncommit-files file1 file2 ... ' removes files from last commit"
+   else
+      git reset --soft HEAD~1 # goto previous commit temporarily
+      git reset HEAD $@       # remove list of files from staged index (does not delete them)
+      git commit -c ORIG_HEAD # commit staged files under original head
+   fi
+   
+}


### PR DESCRIPTION
This function is very useful because it allows you to remove specific files from a commit that were accidentally commited.
Includes a detailed README.md for the user.

Please Label this pull request with hacktoberfest-accepted before merging. Thank you. Labels are assigned on the right side of the pull request window.