### PR TITLE
add pdfcompz

### DIFF
--- a/pdfcompz/pdfcompz.sh
+++ b/pdfcompz/pdfcompz.sh
@@ -1,0 +1,10 @@
+figlet pdf2compz
+echo "script made by fazriachyar"
+read -p "Enter file name (example: filename.pdf) :" namafile
+echo "loading file..."
+sleep 3
+echo "inputting file..."
+sleep 2
+echo "wait a minute......."
+gs -sDEVICE=pdfwrite -dCompatibilityLevel=1.4 -dPDFSETTINGS=/ebook -dNOPAUSE -dQUIET -dBATCH -sOutputFile=compressed.pdf $namafile
+figlet finished

--- a/pdfcompz/readme.md
+++ b/pdfcompz/readme.md
@@ -1,0 +1,23 @@
+## PDF COMPZ
+Compress pdf size using ghostscript into half size.
+
+Ghostscript is an interpreter for the PostScript®  language and PDF files. It is available under either the GNU GPL Affero license or  licensed for commercial use from Artifex Software, Inc. It has been under active development for over 30 years and has been ported to several different systems during this time. Ghostscript consists of a PostScript interpreter layer and a graphics library.
+
+## REQUIREMENTS
+
+```
+sudo apt-get install ghostscript
+sudo apt-get install figlet
+sudo chmod 774 pdfcompz.sh
+```
+
+install this package or run requirements.sh
+
+## USAGE
+
+put your pdf file inside this directory with .pdf extension
+and run pdfcompz.sh
+
+```
+./pdfcompz.sh
+```

--- a/pdfcompz/requirements.sh
+++ b/pdfcompz/requirements.sh
@@ -1,0 +1,2 @@
+sudo apt-get install ghostscript
+sudo apt-get install figlet


### PR DESCRIPTION
add pdfcompz, simple bash script can help student to compress their pdf file to smaller size.
using ghostscript as an intrepeter.